### PR TITLE
VSTS-3397 - Maropost Subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 *.gem
+vendor/bundle

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
 --color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.3
+  Exclude:
+    - 'bin/**/*'
+    - 'vendor/**/*'
+Documentation:
+  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
+Metrics/LineLength:
+  Max: 130
+Metrics/MethodLength:
+  Max: 25
+Style/Lambda:
+  EnforcedStyle: literal

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,4 @@
+SimpleCov.start do
+  SimpleCov.minimum_coverage 100.00
+end
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in maropost.gemspec
 gemspec
-
-group :development, :test do
-  gem 'bundler', '~> 1.15'
-  gem 'rake', '~> 12.0'
-  gem 'rspec', '~> 3.5'
-  gem 'webmock'
-end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: %i[spec rubocop]
+
+RuboCop::RakeTask.new

--- a/lib/maropost.rb
+++ b/lib/maropost.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 require 'active_support/all'
 require 'json'
 require 'rest_client'
 require 'rest_client/jogger'
 require 'maropost/version'
 require 'maropost/configuration'
+require 'maropost/service'
 require 'maropost/api'
 require 'maropost/contact'
 require 'maropost/do_not_mail_list'

--- a/lib/maropost.rb
+++ b/lib/maropost.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'json'
 require 'rest_client'
 require 'rest_client/jogger'

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -1,93 +1,86 @@
 module Maropost
   class Api
-    def self.find(email)
-      response = request(:get,
-                         maropost_url('contacts/email.json', "contact[email]=#{CGI::escape(email)}"))
-      Maropost::Contact.new(JSON.parse response.body)
-    rescue RestClient::ResourceNotFound
-      nil
-    end
-
-    def self.update_subscriptions(contact)
-      if existing_contact = find(contact.email)
-        contact.id = existing_contact.id
-        update(contact)
-      else
-        create(contact)
+    class << self
+      def find(email)
+        raise ArgumentError, 'must provide email' if email.blank?
+        response = request(
+          :get,
+          maropost_url('contacts/email.json', "contact[email]=#{CGI.escape(email)}")
+        )
+        Maropost::Contact.new(JSON.parse(response.body))
+      rescue RestClient::ResourceNotFound
+        nil
       end
-      update_do_not_mail_list(contact)
-    end
 
-    def self.create(contact)
-      response = request(:post,
-                          maropost_url('contacts.json'),
-                          create_or_update_payload(contact))
-      Maropost::Contact.new(JSON.parse response.body)
-    rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-      contact.errors << 'Unable to create or update contact'
-      contact
-    end
+      def update_subscriptions(contact)
+        if existing_contact = find(contact.email)
+          contact.id = existing_contact.id
+          update(contact)
+        else
+          create(contact)
+        end
+        update_do_not_mail_list(contact)
+      end
 
-    def self.update(contact)
-      response = request(:put,
-                         maropost_url("contacts/#{contact.id}.json"),
-                         create_or_update_payload(contact))
-      Maropost::Contact.new(JSON.parse response.body)
-    rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-      contact.errors << 'Unable to update contact'
-      contact
-    end
+      def create(contact)
+        response = request(
+          :post,
+          maropost_url('contacts.json'),
+          create_or_update_payload(contact)
+        )
+        Maropost::Contact.new(JSON.parse(response.body))
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        contact.errors << 'Unable to create or update contact'
+        contact
+      end
 
-    private
+      def update(contact)
+        response = request(
+          :put,
+          maropost_url("contacts/#{contact.id}.json"),
+          create_or_update_payload(contact)
+        )
+        Maropost::Contact.new(JSON.parse(response.body))
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        contact.errors << 'Unable to update contact'
+        contact
+      end
 
-    def self.maropost_url(path, query = nil)
-      URI.join(Maropost.configuration.api_url, path).tap { |u| query && u.query = query }.to_s
-    end
+      private
 
-    def self.request(method, url, payload = {})
-      RestClient::Request.logged_request(
-        method: method,
-        timeout: 10,
-        open_timeout: 10,
-        url: url,
-        payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
-        headers: { content_type: 'application/json', accept: 'application/json' },
-        verify_ssl: OpenSSL::SSL::VERIFY_PEER
-      )
-    end
+      def maropost_url(path, query = nil)
+        uri = URI.join(Maropost.configuration.api_url, path)
+        uri.tap { |u| query && u.query = query }.to_s
+      end
 
-    def self.create_or_update_payload(contact)
-      {
-        contact:
-          {
+      def request(method, url, payload = {})
+        RestClient::Request.logged_request(
+          method: method,
+          read_timeout: 10,
+          open_timeout: 5,
+          url: url,
+          payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
+          headers: { content_type: 'application/json', accept: 'application/json' },
+          verify_ssl: OpenSSL::SSL::VERIFY_PEER
+        )
+      end
+
+      def create_or_update_payload(contact)
+        {
+          contact: {
             email: contact.email,
             phone: contact.phone_number,
-            custom_field:
-              {
-                ama_rewards: contact.ama_rewards,
-                ama_membership: contact.ama_membership,
-                ama_insurance: contact.ama_insurance,
-                ama_travel: contact.ama_travel,
-                ama_new_member_series: contact.ama_new_member_series,
-                ama_fleet_safety: contact.ama_fleet_safety,
-                ovrr_personal: contact.ovrr_personal,
-                ovrr_business: contact.ovrr_business,
-                ovrr_associate: contact.ovrr_associate,
-                ama_vr_reminder: contact.ama_vr_reminder,
-                ama_vr_reminder_email: contact.ama_vr_reminder_email,
-                ama_vr_reminder_sms: contact.ama_vr_reminder_sms,
-                ama_vr_reminder_autocall: contact.ama_vr_reminder_autocall,
-                cell_phone_number: contact.cell_phone_number
-              }
+            custom_field: contact.list_parameters
           }
-      }
-    end
+        }
+      end
 
-    def self.update_do_not_mail_list(contact)
-      if contact.subscribed_to_any_lists?
-        DoNotMailList.delete(contact)
-      else
-        DoNotMailList.create(contact)
+      def update_do_not_mail_list(contact)
+        if contact.subscribed_to_any_lists?
+          DoNotMailList.delete(contact)
+        else
+          DoNotMailList.create(contact)
+        end
       end
     end
   end

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -1,69 +1,59 @@
+# frozen_string_literal: true
+
 module Maropost
   class Api
     class << self
       def find(email)
         raise ArgumentError, 'must provide email' if email.blank?
-        response = request(
-          :get,
-          maropost_url('contacts/email.json', "contact[email]=#{CGI.escape(email)}")
+        service = Service.new(
+          method: :get,
+          path: 'contacts/email.json',
+          query: {
+            'contact[email]': email,
+            'auth_token': Maropost.configuration.auth_token
+          }
         )
-        Maropost::Contact.new(JSON.parse(response.body))
+        response = JSON.parse(service.execute!.body)
+        Maropost::Contact.new(response)
       rescue RestClient::ResourceNotFound
         nil
       end
 
       def update_subscriptions(contact)
-        if existing_contact = find(contact.email)
-          contact.id = existing_contact.id
-          update(contact)
-        else
-          create(contact)
-        end
+        to_maropost(
+          find(contact.email),
+          contact
+        )
         update_do_not_mail_list(contact)
       end
 
       def create(contact)
-        response = request(
-          :post,
-          maropost_url('contacts.json'),
-          create_or_update_payload(contact)
+        service = Service.new(
+          method: :post,
+          path: 'contacts.json',
+          payload: create_or_update_payload(contact)
         )
-        Maropost::Contact.new(JSON.parse(response.body))
-      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        response = JSON.parse(service.execute!.body)
+        Maropost::Contact.new(response)
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest
         contact.errors << 'Unable to create or update contact'
         contact
       end
 
       def update(contact)
-        response = request(
-          :put,
-          maropost_url("contacts/#{contact.id}.json"),
-          create_or_update_payload(contact)
+        service = Service.new(
+          method: :put,
+          path: "contacts/#{contact.id}.json",
+          payload: create_or_update_payload(contact)
         )
-        Maropost::Contact.new(JSON.parse(response.body))
-      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        response = JSON.parse(service.execute!.body)
+        Maropost::Contact.new(response)
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest
         contact.errors << 'Unable to update contact'
         contact
       end
 
       private
-
-      def maropost_url(path, query = nil)
-        uri = URI.join(Maropost.configuration.api_url, path)
-        uri.tap { |u| query && u.query = query }.to_s
-      end
-
-      def request(method, url, payload = {})
-        RestClient::Request.logged_request(
-          method: method,
-          read_timeout: 10,
-          open_timeout: 5,
-          url: url,
-          payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
-          headers: { content_type: 'application/json', accept: 'application/json' },
-          verify_ssl: OpenSSL::SSL::VERIFY_PEER
-        )
-      end
 
       def create_or_update_payload(contact)
         {
@@ -73,6 +63,15 @@ module Maropost
             custom_field: contact.list_parameters
           }
         }
+      end
+
+      def to_maropost(existing, contact)
+        if existing
+          contact.id = existing.id
+          update(contact)
+        else
+          create(contact)
+        end
       end
 
       def update_do_not_mail_list(contact)

--- a/lib/maropost/configuration.rb
+++ b/lib/maropost/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Maropost
   attr_accessor :configuration
 
@@ -10,11 +12,14 @@ module Maropost
   end
 
   class Configuration
-    attr_accessor :api_url, :auth_token
+    attr_accessor :api_url, :auth_token, :open_timeout, :read_timeout
 
-    def initialize
-      self.api_url = "http://example.com"
-      self.auth_token = "auth_token"
+    def open_timeout
+      @open_timeout || 5
+    end
+
+    def read_timeout
+      @read_timeout || 10
     end
   end
 end

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -1,39 +1,56 @@
 module Maropost
   class Contact
-    attr_accessor :id, :email,
-                  :ama_rewards, :ama_membership, :ama_insurance, :ama_travel, :ama_new_member_series, :ama_fleet_safety,
-                  :ovrr_personal, :ovrr_business, :ovrr_associate,
-                  :ama_vr_reminder, :ama_vr_reminder_email, :ama_vr_reminder_sms, :ama_vr_reminder_autocall,
-                  :phone_number, :cell_phone_number, :errors
+    ATTRIBUTES = %i(
+      id
+      email
+      phone_number
+      cell_phone_number
+      lists
+      errors
+    ).freeze
+    LISTS = %i(
+      ama_rewards
+      ama_membership
+      ama_insurance
+      ama_travel
+      ama_new_member_series
+      ama_fleet_safety
+      ovrr_personal
+      ovrr_business
+      ovrr_associate
+      ama_vr_reminder
+      ama_vr_reminder_email
+      ama_vr_reminder_sms
+      ama_vr_reminder_autocall
+    ).freeze
 
-    def initialize(data)
-      data = data.stringify_keys
-      self.id = data['id']
-      self.email = data['email']
-      self.ama_rewards = data['ama_rewards'] || '0'
-      self.ama_membership = data['ama_membership'] || '0'
-      self.ama_insurance = data['ama_insurance'] || '0'
-      self.ama_travel = data['ama_travel'] || '0'
-      self.ama_new_member_series = data['ama_new_member_series'] || '0'
-      self.ama_fleet_safety = data['ama_fleet_safety'] || '0'
-      self.ovrr_personal = data['ovrr_personal'] || ''
-      self.ovrr_business = data['ovrr_business'] || ''
-      self.ovrr_associate = data['ovrr_associate'] || ''
-      self.ama_vr_reminder = data['ama_vr_reminder'] || '0'
-      self.ama_vr_reminder_email = data['ama_vr_reminder_email'] || '0'
-      self.ama_vr_reminder_sms = data['ama_vr_reminder_sms'] || '0'
-      self.ama_vr_reminder_autocall = data['ama_vr_reminder_autocall'] || '0'
-      self.phone_number = data['phone'] || ''
-      self.cell_phone_number = data['cell_phone_number'] || ''
+    attr_accessor(*ATTRIBUTES)
 
+    def initialize(opts = {})
+      data = opts.with_indifferent_access
+      self.id = data[:id]
+      self.email = data[:email]
+      self.phone_number = data[:phone]
+      self.cell_phone_number = data[:cell_phone_number]
       self.errors = []
+      self.lists = {}
+      initialize_lists(data)
     end
 
     def subscribed_to_any_lists?
-      ama_rewards.eql?('1') || ama_membership.eql?('1') || ama_insurance.eql?('1') || ama_travel.eql?('1') ||
-        ama_new_member_series.eql?('1') || ama_fleet_safety.eql?('1') ||
-        ama_vr_reminder.eql?('1') || ama_vr_reminder_email.eql?('1') || ama_vr_reminder_sms.eql?('1') ||
-        ama_vr_reminder_autocall.eql?('1')
+      lists.values.any? { |v| v == '1' }
+    end
+
+    def list_parameters
+      { cell_phone_number: cell_phone_number }.merge(lists)
+    end
+
+    private
+
+    def initialize_lists(opts = {})
+      LISTS.each do |list|
+        lists[list] = opts.fetch(list, 0).to_s
+      end
     end
   end
 end

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 module Maropost
   class Contact
-    ATTRIBUTES = %i(
+    ATTRIBUTES = %i[
       id
       email
       phone_number
       cell_phone_number
       lists
       errors
-    ).freeze
-    LISTS = %i(
+    ].freeze
+    LISTS = %i[
       ama_rewards
       ama_membership
       ama_insurance
@@ -22,7 +24,7 @@ module Maropost
       ama_vr_reminder_email
       ama_vr_reminder_sms
       ama_vr_reminder_autocall
-    ).freeze
+    ].freeze
 
     attr_accessor(*ATTRIBUTES)
 

--- a/lib/maropost/do_not_mail_list.rb
+++ b/lib/maropost/do_not_mail_list.rb
@@ -1,12 +1,18 @@
+# frozen_string_literal: true
+
 module Maropost
   class DoNotMailList
     class << self
       def exists?(contact)
-        response = request(
-          :get,
-          maropost_url('global_unsubscribes/email.json', "contact[email]=#{CGI.escape(contact.email)}")
+        service = Service.new(
+          method: :get,
+          path: 'global_unsubscribes/email.json',
+          query: {
+            'contact[email]': contact.email,
+            'auth_token': Maropost.configuration.auth_token
+          }
         )
-        JSON.parse(response.body)
+        response = JSON.parse(service.execute!.body)
         response['id'].present?
       rescue RestClient::ResourceNotFound, RestClient::BadRequest => e
         contact.errors << "Unexpected error occurred. Error: #{e.message}"
@@ -15,11 +21,12 @@ module Maropost
 
       def create(contact)
         payload = { 'global_unsubscribe': { 'email': contact.email } }
-        request(
-          :post,
-          maropost_url('global_unsubscribes.json'),
-          payload
+        service = Service.new(
+          method: :post,
+          path: 'global_unsubscribes.json',
+          payload: payload
         )
+        service.execute!
         contact
       rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
         contact.errors << "Unable to subscribe contact. Error: #{e.message}"
@@ -27,33 +34,18 @@ module Maropost
       end
 
       def delete(contact)
-        request(
-          :delete,
-          maropost_url('global_unsubscribes/delete.json', "email=#{CGI.escape(contact.email)}")
+        service = Service.new(
+          method: :delete,
+          path: 'global_unsubscribes/delete.json',
+          query: {
+            'email': contact.email
+          }
         )
+        service.execute!
         contact
       rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
         contact.errors << "Unable to unsubscribe contact. Error: #{e.message}"
         contact
-      end
-
-      private
-
-      def maropost_url(path, query = nil)
-        uri = URI.join(Maropost.configuration.api_url, path)
-        uri.tap { |u| query && u.query = query }.to_s
-      end
-
-      def request(method, url, payload = {})
-        RestClient::Request.logged_request(
-          method: method,
-          read_timeout: 10,
-          open_timeout: 5,
-          url: url,
-          payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
-          headers: { content_type: 'application/json', accept: 'application/json' },
-          verify_ssl: OpenSSL::SSL::VERIFY_PEER
-        )
       end
     end
   end

--- a/lib/maropost/do_not_mail_list.rb
+++ b/lib/maropost/do_not_mail_list.rb
@@ -1,53 +1,60 @@
 module Maropost
   class DoNotMailList
-    def self.exists?(contact)
-      response = request(:get,
-                         maropost_url('global_unsubscribes/email.json', "contact[email]=#{CGI::escape(contact.email)}"))
-      JSON.parse response.body
+    class << self
+      def exists?(contact)
+        response = request(
+          :get,
+          maropost_url('global_unsubscribes/email.json', "contact[email]=#{CGI.escape(contact.email)}")
+        )
+        JSON.parse(response.body)
+        response['id'].present?
+      rescue RestClient::ResourceNotFound, RestClient::BadRequest => e
+        contact.errors << "Unexpected error occurred. Error: #{e.message}"
+        contact
+      end
 
-      response['id'] ? true : false
-    rescue RestClient::ResourceNotFound, RestClient::BadRequest => e
-      contact.errors << "Unexpected error occurred. Error: #{e.message}"
-      contact
-    end
+      def create(contact)
+        payload = { 'global_unsubscribe': { 'email': contact.email } }
+        request(
+          :post,
+          maropost_url('global_unsubscribes.json'),
+          payload
+        )
+        contact
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        contact.errors << "Unable to subscribe contact. Error: #{e.message}"
+        contact
+      end
 
-    def self.create(contact)
-      payload = { 'global_unsubscribe': { 'email': contact.email } }
+      def delete(contact)
+        request(
+          :delete,
+          maropost_url('global_unsubscribes/delete.json', "email=#{CGI.escape(contact.email)}")
+        )
+        contact
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
+        contact.errors << "Unable to unsubscribe contact. Error: #{e.message}"
+        contact
+      end
 
-      request(:post,
-              maropost_url('global_unsubscribes.json'),
-              payload)
-      contact
-    rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-      contact.errors << "Unable to subscribe contact. Error: #{e.message}"
-      contact
-    end
+      private
 
-    def self.delete(contact)
-      request(:delete,
-              maropost_url('global_unsubscribes/delete.json', "email=#{CGI::escape(contact.email)}"))
-      contact
-    rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-      contact.errors << "Unable to unsubscribe contact. Error: #{e.message}"
-      contact
-    end
+      def maropost_url(path, query = nil)
+        uri = URI.join(Maropost.configuration.api_url, path)
+        uri.tap { |u| query && u.query = query }.to_s
+      end
 
-    private
-
-    def self.maropost_url(path, query = nil)
-      URI.join(Maropost.configuration.api_url, path).tap { |u| query && u.query = query }.to_s
-    end
-
-    def self.request(method, url, payload = {})
-      RestClient::Request.logged_request(
-        method: method,
-        read_timeout: 10,
-        open_timeout: 5,
-        url: url,
-        payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
-        headers: { content_type: 'application/json', accept: 'application/json' },
-        verify_ssl: OpenSSL::SSL::VERIFY_PEER
-      )
+      def request(method, url, payload = {})
+        RestClient::Request.logged_request(
+          method: method,
+          read_timeout: 10,
+          open_timeout: 5,
+          url: url,
+          payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json,
+          headers: { content_type: 'application/json', accept: 'application/json' },
+          verify_ssl: OpenSSL::SSL::VERIFY_PEER
+        )
+      end
     end
   end
 end

--- a/lib/maropost/service.rb
+++ b/lib/maropost/service.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Maropost
+  class Service
+    attr_accessor :method, :path, :query, :payload, :request_id
+
+    def initialize(opts = {})
+      self.method = opts.fetch(:method)
+      self.path = opts.fetch(:path)
+      self.payload = opts.fetch(:payload, {}) # optional
+      self.query = opts[:query] # optional
+      self.request_id = SecureRandom.uuid
+    end
+
+    def execute!
+      RestClient::Request.logged_request(params)
+    end
+
+    private
+
+    def maropost_url
+      self.query &&= encode_query(query)
+      uri = URI.join(Maropost.configuration.api_url, path)
+      uri.tap { |u| query && u.query = query }.to_s
+    end
+
+    def encode_query(hash)
+      RestClient::Utils.encode_query_string(hash)
+    end
+
+    def get?
+      method.to_s.casecmp('get').zero?
+    end
+
+    def base_params
+      {
+        method: method,
+        read_timeout: Maropost.configuration.read_timeout,
+        open_timeout: Maropost.configuration.open_timeout,
+        url: maropost_url,
+        headers: {
+          content_type: 'application/json',
+          accept: 'application/json',
+          request_id: request_id
+        },
+        verify_ssl: OpenSSL::SSL::VERIFY_PEER
+      }
+    end
+
+    def params
+      return base_params if get?
+      base_params.merge(
+        payload: { auth_token: Maropost.configuration.auth_token }.merge(payload).to_json
+      )
+    end
+  end
+end

--- a/lib/maropost/version.rb
+++ b/lib/maropost/version.rb
@@ -1,3 +1,3 @@
 module Maropost
-  VERSION = '0.3.2'
+  VERSION = '0.5.0'
 end

--- a/lib/maropost/version.rb
+++ b/lib/maropost/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Maropost
   VERSION = '0.5.0'
 end

--- a/maropost.gemspec
+++ b/maropost.gemspec
@@ -1,29 +1,62 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'maropost/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'maropost'
-  spec.version       = Maropost::VERSION
-  spec.authors       = ['Michael van den Beuken', 'Ruben Estevez', 'Jordan Babe', 'Mathieu Gilbert', 'Ryan Jones', 'Darko Dosenovic', 'Jonathan Weyermann', 'Adam Melnyk', 'Kayt Campbell', 'Kathleen Robertson', 'Jesse Doyle', 'Sinead Errity', 'Serene Yew', 'Martin Echtner']
-  spec.email         = ['michael.beuken@gmail.com', 'ruben.a.estevez@gmail.com', 'jorbabe@gmail.com', 'mathieu.gilbert@ama.ab.ca', 'ryan.michael.jones@gmail.com', 'darko.dosenovic@ama.ab.ca', 'jonathan.weyermann@ama.ab.ca', 'adam.melnyk@ama.ab.ca', 'kayt.campbell@ama.ab.ca', 'kathleen.robertson@ama.ab.ca', 'jdoyle@ualberta.ca', 'sinead.errity@ama.ab.ca', 'serene.yew@ama.ab.ca', 'martin.echtner@ama.ab.ca']
-  spec.summary       = %q{Interact with the Maropost API}
-  spec.description   = %q{Interact with the Maropost API}
-  spec.homepage      = 'https://github.com/amaabca/maropost'
-  spec.license       = 'MIT'
+  spec.name = 'maropost'
+  spec.version = Maropost::VERSION
+  spec.authors = [
+    'Michael van den Beuken',
+    'Ruben Estevez',
+    'Jordan Babe',
+    'Ryan Jones',
+    'Darko Dosenovic',
+    'Jonathan Weyermann',
+    'Kayt Campbell',
+    'Jesse Doyle',
+    'Zoie Carnegie',
+    'Sinead Errity',
+    'Serene Yew',
+    'Martin Echtner'
+  ]
+  spec.email = [
+    'michael.beuken@gmail.com',
+    'ruben.a.estevez@gmail.com',
+    'jorbabe@gmail.com',
+    'ryan.michael.jones@gmail.com',
+    'darko.dosenovic@ama.ab.ca',
+    'jonathan.weyermann@ama.ab.ca',
+    'kayt.campbell@ama.ab.ca',
+    'jdoyle@ualberta.ca',
+    'zoie.carnegie@ama.ab.ca',
+    'sinead.errity@ama.ab.ca',
+    'serene.yew@ama.ab.ca',
+    'martin.echtner@ama.ab.ca'
+  ]
+  spec.summary = 'Interact with the Maropost API'
+  spec.description = 'Interact with the Maropost API'
+  spec.homepage = 'https://github.com/amaabca/maropost'
+  spec.license = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
 
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = %w(lib spec)
+  spec.bindir = 'bin'
+  spec.require_paths = %w[lib spec]
 
   spec.add_dependency 'rest-client'
   spec.add_dependency 'rest-client-jogger'
   spec.add_dependency 'activesupport'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '>= 3.0'
+  spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'rubocop', '0.49.1'
+  spec.add_development_dependency 'pry'
 
   spec.required_ruby_version = '>= 2.2'
 end

--- a/maropost.gemspec
+++ b/maropost.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client'
   spec.add_dependency 'rest-client-jogger'
+  spec.add_dependency 'activesupport'
+  spec.add_development_dependency 'simplecov'
 
   spec.required_ruby_version = '>= 2.2'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,11 +1,18 @@
+# frozen_string_literal: true
+
 describe Maropost::Api do
   describe 'find' do
     context 'contact exists on maropost' do
       let(:maropost_contact_response) { File.read File.join('spec', 'fixtures', 'contacts', 'contact.json') }
 
-      it 'returns maropost contact' do
-        stub_find_maropost_contact(email: CGI::escape(maropost_contact_response['email']), body: maropost_contact_response)
+      before(:each) do
+        stub_find_maropost_contact(
+          email: maropost_contact_response['email'],
+          body: maropost_contact_response
+        )
+      end
 
+      it 'returns maropost contact' do
         contact = Maropost::Api.find(maropost_contact_response['email'])
         lists = contact.lists
         expected_contact = JSON.parse maropost_contact_response
@@ -43,7 +50,7 @@ describe Maropost::Api do
 
   describe 'update subscription' do
     let(:contact) { Maropost::Contact.new(id: nil, email: 'test@test.com') }
-    let(:existing_contact) { Maropost::Contact.new(id: 741000000, email: 'test@test.com') }
+    let(:existing_contact) { Maropost::Contact.new(id: 741_000_000, email: 'test@test.com') }
 
     subject { Maropost::Api.update_subscriptions(contact) }
 
@@ -91,11 +98,11 @@ describe Maropost::Api do
   end
 
   describe 'update' do
-    subject { Maropost::Api.update(Maropost::Contact.new(id: 741000000)) }
+    subject { Maropost::Api.update(Maropost::Contact.new(id: 741_000_000)) }
 
     context 'is successful' do
       it 'updates the contact in maropost' do
-        stub_update_maropost_contact(contact_id: 741000000)
+        stub_update_maropost_contact(contact_id: 741_000_000)
         contact = subject
 
         expect(contact.errors).to be_empty
@@ -104,7 +111,7 @@ describe Maropost::Api do
 
     context 'fails' do
       it 'sets an error on contact' do
-        stub_update_maropost_contact(contact_id: 741000000, status: 422)
+        stub_update_maropost_contact(contact_id: 741_000_000, status: 422)
         contact = subject
 
         expect(contact.errors).to include 'Unable to update contact'

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Maropost::Api do
   describe 'find' do
     context 'contact exists on maropost' do
@@ -9,23 +7,23 @@ describe Maropost::Api do
         stub_find_maropost_contact(email: CGI::escape(maropost_contact_response['email']), body: maropost_contact_response)
 
         contact = Maropost::Api.find(maropost_contact_response['email'])
-
+        lists = contact.lists
         expected_contact = JSON.parse maropost_contact_response
         expect(contact.id).to eq expected_contact['id']
         expect(contact.email).to eq expected_contact['email']
-        expect(contact.ama_rewards).to eq expected_contact['ama_rewards']
-        expect(contact.ama_membership).to eq expected_contact['ama_membership']
-        expect(contact.ama_insurance).to eq expected_contact['ama_insurance']
-        expect(contact.ama_travel).to eq expected_contact['ama_travel']
-        expect(contact.ama_new_member_series).to eq expected_contact['ama_new_member_series']
-        expect(contact.ama_fleet_safety).to eq expected_contact['ama_fleet_safety']
-        expect(contact.ovrr_personal).to eq expected_contact['ovrr_personal']
-        expect(contact.ovrr_business).to eq expected_contact['ovrr_business']
-        expect(contact.ovrr_associate).to eq expected_contact['ovrr_associate']
-        expect(contact.ama_vr_reminder).to eq expected_contact['ama_vr_reminder']
-        expect(contact.ama_vr_reminder_email).to eq expected_contact['ama_vr_reminder_email']
-        expect(contact.ama_vr_reminder_sms).to eq expected_contact['ama_vr_reminder_sms']
-        expect(contact.ama_vr_reminder_autocall).to eq expected_contact['ama_vr_reminder_autocall']
+        expect(lists[:ama_rewards]).to eq expected_contact['ama_rewards']
+        expect(lists[:ama_membership]).to eq expected_contact['ama_membership']
+        expect(lists[:ama_insurance]).to eq expected_contact['ama_insurance']
+        expect(lists[:ama_travel]).to eq expected_contact['ama_travel']
+        expect(lists[:ama_new_member_series]).to eq expected_contact['ama_new_member_series']
+        expect(lists[:ama_fleet_safety]).to eq expected_contact['ama_fleet_safety']
+        expect(lists[:ovrr_personal]).to eq expected_contact['ovrr_personal']
+        expect(lists[:ovrr_business]).to eq expected_contact['ovrr_business']
+        expect(lists[:ovrr_associate]).to eq expected_contact['ovrr_associate']
+        expect(lists[:ama_vr_reminder]).to eq expected_contact['ama_vr_reminder']
+        expect(lists[:ama_vr_reminder_email]).to eq expected_contact['ama_vr_reminder_email']
+        expect(lists[:ama_vr_reminder_sms]).to eq expected_contact['ama_vr_reminder_sms']
+        expect(lists[:ama_vr_reminder_autocall]).to eq expected_contact['ama_vr_reminder_autocall']
         expect(contact.phone_number).to eq expected_contact['phone']
         expect(contact.cell_phone_number).to eq expected_contact['cell_phone_number']
       end

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Maropost::Contact do
   describe 'subscribed to any lists' do
     described_class::LISTS.each do |list_name|

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -1,12 +1,9 @@
-require 'spec_helper'
-
 describe Maropost::Contact do
   describe 'subscribed to any lists' do
-    [:ama_rewards, :ama_membership, :ama_insurance, :ama_travel, :ama_new_member_series, :ama_fleet_safety,
-     :ama_vr_reminder, :ama_vr_reminder_email, :ama_vr_reminder_sms, :ama_vr_reminder_autocall].each do |list_name|
+    described_class::LISTS.each do |list_name|
       context "subscribed to #{list_name}" do
         subject { Maropost::Contact.new(list_name => '1').subscribed_to_any_lists? }
-        
+
         it { expect(subject).to be_truthy }
       end
     end

--- a/spec/do_not_mail_list_spec.rb
+++ b/spec/do_not_mail_list_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Maropost::DoNotMailList do
   let(:contact) { Maropost::Contact.new(email: 'test@example.com') }
 

--- a/spec/do_not_mail_list_spec.rb
+++ b/spec/do_not_mail_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Maropost::DoNotMailList do
   let(:contact) { Maropost::Contact.new(email: 'test@example.com') }
 
@@ -8,14 +10,14 @@ describe Maropost::DoNotMailList do
 
     context 'email address is found on list' do
       it 'returns true' do
-        stub_do_not_mail_list_exists({ body: found_response })
+        stub_do_not_mail_list_exists(body: found_response)
         expect(subject).to be_truthy
       end
     end
 
     context 'email address is not found on list' do
       it 'returns false' do
-        stub_do_not_mail_list_exists({ body: not_found_response })
+        stub_do_not_mail_list_exists(body: not_found_response)
         expect(subject).to be_falsey
       end
     end

--- a/spec/maropost_spec.rb
+++ b/spec/maropost_spec.rb
@@ -1,7 +1,13 @@
-require 'spec_helper'
-
 describe Maropost do
   it 'has a version number' do
     expect(Maropost::VERSION).not_to be nil
+  end
+
+  describe '.configure' do
+    it 'yields a Maropost::Configuration instance' do
+      described_class.configure do |config|
+        expect(config).to be_a(Maropost::Configuration)
+      end
+    end
   end
 end

--- a/spec/maropost_spec.rb
+++ b/spec/maropost_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Maropost do
   it 'has a version number' do
     expect(Maropost::VERSION).not_to be nil

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+describe Maropost::Service do
+  describe '#execute!' do
+    context 'with a payload' do
+      subject do
+        described_class.new(
+          method: method,
+          path: 'test.json',
+          payload: { foo: 'bar' }
+        )
+      end
+
+      context 'with a get request' do
+        let(:method) { :get }
+
+        before(:each) do
+          stub_request(:get, /test/)
+            .with(body: nil)
+            .to_return(
+              status: 200,
+              body: '{"success":true}'
+            )
+        end
+
+        it 'ignores the payload' do
+          expect(subject.execute!.code).to eq(200)
+        end
+      end
+
+      context 'with a non-get request' do
+        let(:method) { :post }
+
+        before(:each) do
+          stub_request(:post, /test/)
+            .with(body: '{"auth_token":"auth_token","foo":"bar"}')
+            .to_return(
+              status: 200,
+              body: '{"success":true}'
+            )
+        end
+
+        it 'sends the payload to the api' do
+          expect(subject.execute!.code).to eq(200)
+        end
+      end
+
+      context 'with a query' do
+        subject do
+          described_class.new(
+            method: :get,
+            path: 'test.json',
+            query: {
+              'contact[test]+01': true
+            }
+          )
+        end
+
+        before(:each) do
+          stub_request(:get, /\?contact%5Btest%2B01%5D=true/)
+            .with(body: nil)
+            .to_return(
+              status: 200,
+              body: '{"success":true}'
+            )
+        end
+
+        it 'url encodes the query parameters' do
+          expect(subject.execute!.code).to eq(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'simplecov'
 require 'rspec'
 require 'webmock/rspec'
 require 'maropost'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,20 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 require 'rspec'
 require 'webmock/rspec'
 require 'maropost'
 
 gem_dir = Gem::Specification.find_by_name('maropost').gem_dir
-Dir[File.join(gem_dir, 'spec/support/**/*.rb')].each { |f| puts f; require f }
+Dir[File.join(gem_dir, 'spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Helpers::Requests
   config.color = true
   config.tty = true
+end
+
+Maropost.configure do |config|
+  config.auth_token = 'auth_token'
+  config.api_url = 'https://maropost.example.com/api/123/'
 end


### PR DESCRIPTION
:elephant:

* Add `simplecov` and set the minimum coverage to 100%.
* Add a spec for `Maropost.configure`.
* [**breaking change**] - Refactor `Maropost::Contact` to store
  subscriptions inside a `lists` hash (as opposed to unique
  instance accessors). This allows us to iterate subscriptions
  easily to simplify logic as well as allow for future updates.
* Fix the `DoNotMailList` - previously, the user was not opted
  into the do not mail list when they had no subscriptions.
* Make the `.rspec` file include `spec_helper`. Remove `spec_helper`
  inclusions in individual tests.
* Fix awkward method call syntax in `Maropost::Api`.
* Use `class << self` where possible - this allows for private
  class methods.

SEE: https://amaabca.visualstudio.com/membership_backlog/_queries?id=3397