### PR TITLE
VSTS-3397 - Maropost Subscriptions

### DIFF
--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -75,7 +75,7 @@ module Maropost
       end
 
       def update_do_not_mail_list(contact)
-        if contact.allow_emails? && contact.subscribed_to_any_lists?
+        if contact.allow_emails?
           DoNotMailList.delete(contact)
         else
           DoNotMailList.create(contact)

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -3,7 +3,7 @@
 module Maropost
   class Contact
     ATTRIBUTES = %i[
-      do_not_contact
+      allow_emails
       id
       email
       phone_number
@@ -35,14 +35,14 @@ module Maropost
       self.email = data[:email]
       self.phone_number = data[:phone]
       self.cell_phone_number = data[:cell_phone_number]
-      self.do_not_contact = data.fetch(:do_not_contact, false)
+      self.allow_emails = data.fetch(:allow_emails) { !DoNotMailList.exists?(self) }
       self.errors = []
       self.lists = {}
       initialize_lists(data)
     end
 
     def allow_emails?
-      @allow_emails ||= email.present? && !do_not_contact && !DoNotMailList.exists?(self)
+      allow_emails
     end
 
     def subscribed_to_any_lists?

--- a/lib/maropost/do_not_mail_list.rb
+++ b/lib/maropost/do_not_mail_list.rb
@@ -14,9 +14,8 @@ module Maropost
         )
         response = JSON.parse(service.execute!.body)
         response['id'].present?
-      rescue RestClient::ResourceNotFound, RestClient::BadRequest => e
-        contact.errors << "Unexpected error occurred. Error: #{e.message}"
-        contact
+      rescue RestClient::ResourceNotFound, RestClient::BadRequest
+        false
       end
 
       def create(contact)
@@ -27,10 +26,8 @@ module Maropost
           payload: payload
         )
         service.execute!
-        contact
-      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-        contact.errors << "Unable to subscribe contact. Error: #{e.message}"
-        contact
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest
+        false
       end
 
       def delete(contact)
@@ -42,10 +39,8 @@ module Maropost
           }
         )
         service.execute!
-        contact
-      rescue RestClient::UnprocessableEntity, RestClient::BadRequest => e
-        contact.errors << "Unable to unsubscribe contact. Error: #{e.message}"
-        contact
+      rescue RestClient::UnprocessableEntity, RestClient::BadRequest
+        false
       end
     end
   end

--- a/lib/maropost/version.rb
+++ b/lib/maropost/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Maropost
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
 describe Maropost::Api do
+  let(:email) { 'test+001@test.com' }
+
   describe 'find' do
     context 'contact exists on maropost' do
       let(:maropost_contact_response) { read_fixture('contacts', 'contact.json') }
 
       before(:each) do
         stub_find_maropost_contact(
-          email: maropost_contact_response['email'],
+          email: email,
           body: maropost_contact_response
         )
       end
 
       it 'returns maropost contact' do
-        contact = Maropost::Api.find(maropost_contact_response['email'])
+        contact = Maropost::Api.find(email)
         lists = contact.lists
         expected_contact = JSON.parse maropost_contact_response
         expect(contact.id).to eq expected_contact['id']
@@ -37,7 +39,6 @@ describe Maropost::Api do
     end
 
     context 'contact does not exist on maropost' do
-      let(:email) { 'test@test.com' }
       it 'returns nil' do
         stub_find_maropost_contact(email: email, status: 404)
 
@@ -49,8 +50,8 @@ describe Maropost::Api do
   end
 
   describe 'update subscription' do
-    let(:contact) { Maropost::Contact.new(id: nil, email: 'test@test.com') }
-    let(:existing_contact) { Maropost::Contact.new(id: 741_000_000, email: 'test@test.com') }
+    let(:contact) { Maropost::Contact.new(id: nil, email: email) }
+    let(:existing_contact) { Maropost::Contact.new(id: 741_000_000, email: email) }
 
     subject { Maropost::Api.update_subscriptions(contact) }
 
@@ -58,20 +59,20 @@ describe Maropost::Api do
       stub_find_maropost_contact(email: contact.email)
       stub_update_maropost_contact(contact_id: existing_contact.id)
       stub_do_not_mail_list_exists(
-        email: 'test@test.com',
+        email: 'test+001@test.com',
         body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json')
       )
     end
 
     context 'contact exists on maropost' do
       it 'calls update' do
-        stub_do_not_mail_list_create
+        stub_do_not_mail_list_delete
         subject
         expect(contact.id).to eq existing_contact.id
       end
 
       context 'subscribing to a list' do
-        let(:contact) { Maropost::Contact.new(id: nil, email: 'test@test.com', ama_rewards: '1') }
+        let(:contact) { Maropost::Contact.new(id: nil, email: email, ama_rewards: '1') }
 
         it 'removes from do not mail list' do
           expect(Maropost::DoNotMailList).to receive(:delete).with(contact)
@@ -80,19 +81,12 @@ describe Maropost::Api do
       end
 
       context 'explicitly opting into the do not mail list' do
-        let(:contact) { Maropost::Contact.new(id: nil, email: 'test@test.com', ama_rewards: '1', do_not_contact: true) }
+        let(:contact) { Maropost::Contact.new(id: nil, email: email, ama_rewards: '1', allow_emails: false) }
 
         before(:each) do
           stub_do_not_mail_list_create
         end
 
-        it 'adds to do not mail list' do
-          expect(Maropost::DoNotMailList).to receive(:create).with(contact)
-          subject
-        end
-      end
-
-      context 'unsubscribing from all lists' do
         it 'adds to do not mail list' do
           expect(Maropost::DoNotMailList).to receive(:create).with(contact)
           subject
@@ -104,14 +98,14 @@ describe Maropost::Api do
       it 'calls create' do
         expect(Maropost::Api).to receive(:find).with(contact.email).and_return(nil)
         expect(Maropost::Api).to receive(:create).with(contact)
-        stub_do_not_mail_list_create
+        stub_do_not_mail_list_delete
         subject
       end
     end
   end
 
   describe 'update' do
-    subject { Maropost::Api.update(Maropost::Contact.new(id: 741_000_000)) }
+    subject { Maropost::Api.update(Maropost::Contact.new(id: 741_000_000, email: email)) }
 
     context 'is successful' do
       it 'updates the contact in maropost' do
@@ -129,7 +123,7 @@ describe Maropost::Api do
   end
 
   describe 'create' do
-    subject { Maropost::Api.create(Maropost::Contact.new(email: 'test@test.com')) }
+    subject { Maropost::Api.create(Maropost::Contact.new(email: email)) }
 
     context 'is successful' do
       it 'creates the contact in maropost' do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -3,6 +3,13 @@
 describe Maropost::Api do
   let(:email) { 'test+001@test.com' }
 
+  before(:each) do
+    stub_do_not_mail_list_exists(
+      email: email,
+      body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json')
+    )
+  end
+
   describe 'find' do
     context 'contact exists on maropost' do
       let(:maropost_contact_response) { read_fixture('contacts', 'contact.json') }
@@ -58,10 +65,6 @@ describe Maropost::Api do
     before(:each) do
       stub_find_maropost_contact(email: contact.email)
       stub_update_maropost_contact(contact_id: existing_contact.id)
-      stub_do_not_mail_list_exists(
-        email: 'test+001@test.com',
-        body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json')
-      )
     end
 
     context 'contact exists on maropost' do

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 describe Maropost::Contact do
+  let(:email) { 'test+001@test.com' }
+
   describe 'subscribed to any lists' do
     described_class::LISTS.each do |list_name|
       context "subscribed to #{list_name}" do
-        subject { Maropost::Contact.new(list_name => '1').subscribed_to_any_lists? }
+        subject { Maropost::Contact.new(list_name => '1', email: email).subscribed_to_any_lists? }
 
         it { expect(subject).to be_truthy }
       end
     end
 
     context 'not subscribed to any lists' do
-      it { expect(Maropost::Contact.new({}).subscribed_to_any_lists?).to be_falsey }
+      it { expect(Maropost::Contact.new(email: email).subscribed_to_any_lists?).to be_falsey }
     end
   end
 end

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -3,6 +3,13 @@
 describe Maropost::Contact do
   let(:email) { 'test+001@test.com' }
 
+  before(:each) do
+    stub_do_not_mail_list_exists(
+      email: email,
+      body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json')
+    )
+  end
+
   describe 'subscribed to any lists' do
     described_class::LISTS.each do |list_name|
       context "subscribed to #{list_name}" do

--- a/spec/do_not_mail_list_spec.rb
+++ b/spec/do_not_mail_list_spec.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 describe Maropost::DoNotMailList do
-  let(:contact) { Maropost::Contact.new(email: 'test+001@test.com') }
+  let(:email) { 'test+001@test.com' }
+  let(:contact) { Maropost::Contact.new(email: email) }
+
+  before(:each) do
+    stub_do_not_mail_list_exists(
+      email: email,
+      body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json')
+    )
+  end
 
   describe 'GET #exists?' do
     subject { Maropost::DoNotMailList.exists?(contact) }

--- a/spec/do_not_mail_list_spec.rb
+++ b/spec/do_not_mail_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Maropost::DoNotMailList do
-  let(:contact) { Maropost::Contact.new(email: 'test@example.com') }
+  let(:contact) { Maropost::Contact.new(email: 'test+001@test.com') }
 
   describe 'GET #exists?' do
     subject { Maropost::DoNotMailList.exists?(contact) }
@@ -11,21 +11,21 @@ describe Maropost::DoNotMailList do
     context 'email address is found on list' do
       it 'returns true' do
         stub_do_not_mail_list_exists(body: found_response)
-        expect(subject).to be_truthy
+        expect(subject).to be true
       end
     end
 
     context 'email address is not found on list' do
       it 'returns false' do
         stub_do_not_mail_list_exists(body: not_found_response)
-        expect(subject).to be_falsey
+        expect(subject).to be false
       end
     end
 
     context 'raises exception' do
       it 'returns false' do
         stub_do_not_mail_list_exists(status: 400)
-        expect(subject.errors).not_to be_empty
+        expect(subject).to be false
       end
     end
   end
@@ -34,18 +34,16 @@ describe Maropost::DoNotMailList do
     subject { Maropost::DoNotMailList.create(contact) }
 
     context 'successfully added to do not mail list' do
-      it 'no errors exist' do
+      it 'returns truthy' do
         stub_do_not_mail_list_create(status: 200)
-
-        expect(subject.errors).to be_empty
+        expect(subject).to be_truthy
       end
     end
 
     context 'raises exception' do
-      it 'adds errors to contact' do
+      it 'returns false' do
         stub_do_not_mail_list_create(status: 422)
-
-        expect(subject.errors).not_to be_empty
+        expect(subject).to be false
       end
     end
   end
@@ -54,16 +52,16 @@ describe Maropost::DoNotMailList do
     subject { Maropost::DoNotMailList.delete(contact) }
 
     context 'successfully added to do not mail list' do
-      it 'no errors exist' do
+      it 'returns truthy' do
         stub_do_not_mail_list_delete(status: 200)
-        expect(subject.errors).to be_empty
+        expect(subject).to be_truthy
       end
     end
 
     context 'raises exception' do
-      it 'adds errors to contact' do
+      it 'returns false' do
         stub_do_not_mail_list_delete(status: 422)
-        expect(subject.errors).not_to be_empty
+        expect(subject).to be false
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 require 'rspec'
 require 'webmock/rspec'
 require 'maropost'
+require 'pry'
 
 gem_dir = Gem::Specification.find_by_name('maropost').gem_dir
 Dir[File.join(gem_dir, 'spec/support/**/*.rb')].each { |f| require f }
@@ -13,6 +14,10 @@ RSpec.configure do |config|
   config.include Helpers::Requests
   config.color = true
   config.tty = true
+
+  config.before(:each) do
+    stub_do_not_mail_list_exists(body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json'))
+  end
 end
 
 Maropost.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,10 +14,6 @@ RSpec.configure do |config|
   config.include Helpers::Requests
   config.color = true
   config.tty = true
-
-  config.before(:each) do
-    stub_do_not_mail_list_exists(body: read_fixture('do_not_mail_list', 'do_not_mail_not_found.json'))
-  end
 end
 
 Maropost.configure do |config|

--- a/spec/support/helpers/requests.rb
+++ b/spec/support/helpers/requests.rb
@@ -42,7 +42,7 @@ module Helpers
     def stub_do_not_mail_list_exists(opts = {})
       status = opts.fetch(:status, 200)
       body = opts.fetch(:body) { '' }
-      email = opts.fetch(:email) { 'test@example.com' }
+      email = opts.fetch(:email) { 'test+001@test.com' }
       url = maropost_url(
         'global_unsubscribes/email.json',
         'contact[email]': email,
@@ -64,8 +64,8 @@ module Helpers
     end
 
     def stub_do_not_mail_list_delete(opts = {})
-      status = opts.fetch(:status, 200)
-      email = opts.fetch(:email) { 'test@example.com' }
+      status = opts.fetch(:status, 204)
+      email = opts.fetch(:email) { 'test+001@test.com' }
       url = maropost_url(
         'global_unsubscribes/delete.json',
         'email': email


### PR DESCRIPTION
:elephant:

* Use positive logic (`allow_emails`) as opposed to negative logic (`do_not_call`). The semantics were causing confusion.
* Fix do not call list logic. We need to query the
  DoNotMailList when a contact is instantiated. This is used
  to determine if we need to opt in/opt out of the list
  depending on parameters.
* Fix tests - they were a little messed up testing the incorrect
  conditions.
* `DoNotMailList` class methods now return a truthy/false
  boolean value on success or failure. We weren't using the
  return value, so we could remove some error handling logic.
* Bump version.

SEE: https://amaabca.visualstudio.com/membership_backlog/_queries?id=3397