### PR TITLE
Allow changing email to an existing maropost contact

### DIFF
--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -69,6 +69,8 @@ module Maropost
           contact = update(new_email_contact)
         end
 
+        update_do_not_mail_list(contact) if contact
+
         contact
       end
 

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -54,20 +54,10 @@ module Maropost
       end
 
       def change_email(old_email, new_email)
-        contact = nil
         old_email_contact = find(old_email)
         new_email_contact = find(new_email)
 
-        if old_email_contact.present? && new_email_contact.present?
-          new_email_contact = new_email_contact.merge_settings(old_email_contact)
-          contact = update(new_email_contact)
-          Maropost::DoNotMailList.create(old_email_contact)
-        elsif old_email_contact.present?
-          old_email_contact.email = new_email
-          contact = update(old_email_contact)
-        elsif new_email_contact.present?
-          contact = update(new_email_contact)
-        end
+        contact = update_email(old_email_contact, new_email_contact, new_email)
 
         update_do_not_mail_list(contact) if contact
 
@@ -75,6 +65,23 @@ module Maropost
       end
 
       private
+
+      def update_email(old_contact, new_contact, new_email)
+        contact = nil
+
+        if old_contact.present? && new_contact.present?
+          new_contact = new_contact.merge_settings(old_contact)
+          contact = update(new_contact)
+          Maropost::DoNotMailList.create(old_contact)
+        elsif old_contact.present?
+          old_contact.email = new_email
+          contact = update(old_contact)
+        elsif new_contact.present?
+          contact = update(new_contact)
+        end
+
+        contact
+      end
 
       def create_or_update_payload(contact)
         {

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -54,11 +54,19 @@ module Maropost
       end
 
       def change_email(old_email, new_email)
-        contact = find(old_email)
+        contact = nil
+        old_email_contact = find(old_email)
+        new_email_contact = find(new_email)
 
-        if contact.present?
-          contact.email = new_email
-          contact = update(contact)
+        if old_email_contact.present? && new_email_contact.present?
+          new_email_contact = new_email_contact.merge_settings(old_email_contact)
+          contact = update(new_email_contact)
+          Maropost::DoNotMailList.create(old_email_contact)
+        elsif old_email_contact.present?
+          old_email_contact.email = new_email
+          contact = update(old_email_contact)
+        elsif new_email_contact.present?
+          contact = update(new_email_contact)
         end
 
         contact

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -62,15 +62,14 @@ module Maropost
           new_email_contact = new_email_contact.merge_settings(old_email_contact)
           contact = update(new_email_contact)
           Maropost::DoNotMailList.create(old_email_contact)
-          update_do_not_mail_list(contact)
         elsif old_email_contact.present?
           old_email_contact.email = new_email
           contact = update(old_email_contact)
-          update_do_not_mail_list(contact)
         elsif new_email_contact.present?
           contact = update(new_email_contact)
-          update_do_not_mail_list(contact)
         end
+
+        update_do_not_mail_list(contact) if contact
 
         contact
       end

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -62,14 +62,15 @@ module Maropost
           new_email_contact = new_email_contact.merge_settings(old_email_contact)
           contact = update(new_email_contact)
           Maropost::DoNotMailList.create(old_email_contact)
+          update_do_not_mail_list(contact)
         elsif old_email_contact.present?
           old_email_contact.email = new_email
           contact = update(old_email_contact)
+          update_do_not_mail_list(contact)
         elsif new_email_contact.present?
           contact = update(new_email_contact)
+          update_do_not_mail_list(contact)
         end
-
-        update_do_not_mail_list(contact) if contact
 
         contact
       end

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -56,7 +56,7 @@ module Maropost
     def merge_settings(old_contact)
       self.phone_number = old_contact.phone_number
       self.cell_phone_number = old_contact.cell_phone_number
-      self.lists.each do |list|
+      lists.each do |list|
         lists[list] == '1' ? list : old_contact.lists[list]
       end
 

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -53,6 +53,16 @@ module Maropost
       { cell_phone_number: cell_phone_number }.merge(lists)
     end
 
+    def merge_settings(old_contact)
+      self.phone_number = old_contact.phone_number
+      self.cell_phone_number = old_contact.cell_phone_number
+      self.lists.each do |list|
+        lists[list] == '1' ? list : old_contact.lists[list]
+      end
+
+      self
+    end
+
     private
 
     def initialize_lists(opts = {})

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -56,6 +56,8 @@ module Maropost
     def merge_settings(old_contact)
       self.phone_number = old_contact.phone_number
       self.cell_phone_number = old_contact.cell_phone_number
+      self.allow_emails = old_contact.allow_emails
+
       lists.each do |list|
         lists[list] == '1' ? list : old_contact.lists[list]
       end

--- a/lib/maropost/version.rb
+++ b/lib/maropost/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Maropost
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -145,6 +145,7 @@ describe Maropost::Api do
 
   describe 'change email' do
     let(:existing_contact_maropost_response) { read_fixture('contacts', 'other_existing_contact.json') }
+    let(:old_contact_maropost_response) { read_fixture('contacts', 'contact.json') }
 
     let(:old_email) { 'test+001@test.com' }
     let(:new_email) { 'test@example.com' }
@@ -153,7 +154,6 @@ describe Maropost::Api do
 
     context 'contact does not exist in maropost with the new email' do
       context 'maropost contact exists with old email' do
-        let(:maropost_contact) { JSON.parse read_fixture('contacts', 'contact.json') }
         let(:email_updated_contact) { read_fixture('contacts', 'email_updated_contact.json') }
 
         let(:new_email) { 'updated_email@example.com' }
@@ -191,7 +191,6 @@ describe Maropost::Api do
 
     context 'contact exists in maropost with the new email' do
       context 'maropost contact exists with old email' do
-        let(:old_contact_maropost_response) { read_fixture('contacts', 'contact.json') }
         let(:merged_contact_maropost_response) { read_fixture('contacts', 'merged_contact.json') }
 
         before do

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -144,6 +144,11 @@ describe Maropost::Api do
   end
 
   describe 'change email' do
+    let(:existing_contact_maropost_response) { read_fixture('contacts', 'other_existing_contact.json') }
+
+    let(:old_email) { 'test+001@test.com' }
+    let(:new_email) { 'test@example.com' }
+
     subject { Maropost::Api.change_email(old_email, new_email) }
 
     context 'contact does not exist in maropost with the new email' do
@@ -151,7 +156,6 @@ describe Maropost::Api do
         let(:maropost_contact) { JSON.parse read_fixture('contacts', 'contact.json') }
         let(:email_updated_contact) { read_fixture('contacts', 'email_updated_contact.json') }
 
-        let(:old_email) { 'test+001@test.com' }
         let(:new_email) { 'updated_email@example.com' }
 
         before do
@@ -188,11 +192,7 @@ describe Maropost::Api do
     context 'contact exists in maropost with the new email' do
       context 'maropost contact exists with old email' do
         let(:old_contact_maropost_response) { read_fixture('contacts', 'contact.json') }
-        let(:existing_contact_maropost_response) { read_fixture('contacts', 'other_existing_contact.json') }
         let(:merged_contact_maropost_response) { read_fixture('contacts', 'merged_contact.json') }
-
-        let(:old_email) { 'test+001@test.com' }
-        let(:new_email) { 'test@example.com' }
 
         before do
           stub_find_maropost_contact(email: old_email, status: 200, body: old_contact_maropost_response)
@@ -233,11 +233,6 @@ describe Maropost::Api do
       end
 
       context 'maropost contact does not exist with old email' do
-        let(:existing_contact_maropost_response) { read_fixture('contacts', 'other_existing_contact.json') }
-
-        let(:old_email) { 'test+001@test.com' }
-        let(:new_email) { 'test@example.com' }
-
         before do
           stub_find_maropost_contact(email: old_email, status: 404, body: '{"message": "Contact is not present!"}')
           stub_find_maropost_contact(email: new_email, status: 200, body: existing_contact_maropost_response)

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -199,9 +199,7 @@ describe Maropost::Api do
           stub_find_maropost_contact(email: new_email, status: 200, body: existing_contact_maropost_response)
           stub_do_not_mail_list_exists(email: old_email, status: 404)
           stub_do_not_mail_list_exists(email: new_email, status: 404)
-
           stub_update_maropost_contact(contact_id: 888_000_000, status: 200, body: merged_contact_maropost_response)
-          
           stub_do_not_mail_list_delete(email: new_email)
           stub_do_not_mail_list_create(email: old_email)
         end
@@ -243,11 +241,8 @@ describe Maropost::Api do
         before do
           stub_find_maropost_contact(email: old_email, status: 404, body: '{"message": "Contact is not present!"}')
           stub_find_maropost_contact(email: new_email, status: 200, body: existing_contact_maropost_response)
-
           stub_do_not_mail_list_exists(email: new_email, status: 404)
-
           stub_update_maropost_contact(contact_id: 888_000_000, status: 200, body: existing_contact_maropost_response)
-
           stub_do_not_mail_list_delete(email: new_email)
         end
 

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -213,6 +213,7 @@ describe Maropost::Api do
           expect(updated_contact.email).to eq new_email
           expect(updated_contact.phone_number).to eq merged_contact['phone']
           expect(updated_contact.cell_phone_number).to eq merged_contact['cell_phone_number']
+          expect(updated_contact.allow_emails).to be_truthy
 
           expect(lists[:ama_rewards]).to eq merged_contact['ama_rewards']
           expect(lists[:ama_membership]).to eq merged_contact['ama_membership']
@@ -255,6 +256,7 @@ describe Maropost::Api do
           expect(contact.email).to eq new_email
           expect(contact.phone_number).to eq existing_contact['phone']
           expect(contact.cell_phone_number).to eq existing_contact['cell_phone_number']
+          expect(contact.allow_emails).to be_truthy
 
           expect(lists[:ama_rewards]).to eq existing_contact['ama_rewards']
           expect(lists[:ama_membership]).to eq existing_contact['ama_membership']

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -160,6 +160,7 @@ describe Maropost::Api do
           stub_do_not_mail_list_exists(email: old_email, status: 404)
           stub_do_not_mail_list_exists(email: new_email, status: 404)
           stub_update_maropost_contact(contact_id: 741_000_000, status: 200, body: email_updated_contact)
+          stub_do_not_mail_list_delete(email: new_email)
         end
 
         it 'returns updated contact' do
@@ -200,6 +201,8 @@ describe Maropost::Api do
           stub_do_not_mail_list_exists(email: new_email, status: 404)
 
           stub_update_maropost_contact(contact_id: 888_000_000, status: 200, body: merged_contact_maropost_response)
+          
+          stub_do_not_mail_list_delete(email: new_email)
           stub_do_not_mail_list_create(email: old_email)
         end
 
@@ -244,6 +247,8 @@ describe Maropost::Api do
           stub_do_not_mail_list_exists(email: new_email, status: 404)
 
           stub_update_maropost_contact(contact_id: 888_000_000, status: 200, body: existing_contact_maropost_response)
+
+          stub_do_not_mail_list_delete(email: new_email)
         end
 
         it 'returns new email contact' do

--- a/spec/fixtures/contacts/contact.json
+++ b/spec/fixtures/contacts/contact.json
@@ -16,10 +16,11 @@
   "ovrr_personal": "Watson",
   "ovrr_associate": "Junior",
   "ovrr_business": "Macrocorp",
-  "ama_vr_reminder": "1",
-  "ama_vr_reminder_email": "1",
+  "ama_vr_reminder": "0",
+  "ama_vr_reminder_email": "0",
   "ama_vr_reminder_sms": "1",
   "ama_vr_reminder_autocall": "1",
+  "cell_phone_number": "3213213211",
   "city": null,
   "age": null,
   "postal_code": null,
@@ -103,7 +104,6 @@
   "member_card_holder": null,
   "lob_travel": null,
   "lob_insurance": null,
-  "cell_phone_number": "3213213211",
   "phone_number": null,
   "segment_number": null
 }

--- a/spec/fixtures/contacts/merged_contact.json
+++ b/spec/fixtures/contacts/merged_contact.json
@@ -1,0 +1,20 @@
+{
+  "id": 888000000,
+  "email": "test@example.com",
+  "phone": "123-123-1233",
+  "ama_rewards": "1",
+  "ama_membership": "1",
+  "ama_insurance": "1",
+  "ama_travel": "1",
+  "ama_new_member_series": "1",
+  "ama_fleet_safety": "1",
+  "ovrr_personal": "Watson",
+  "ovrr_associate": "Junior",
+  "ovrr_business": "Macrocorp",
+  "ama_vr_reminder": "1",
+  "ama_vr_reminder_email": "1",
+  "ama_vr_reminder_sms": "1",
+  "ama_vr_reminder_autocall": "1",
+  "cell_phone_number": "3213213211",
+  "phone_number": null
+}

--- a/spec/fixtures/contacts/other_existing_contact.json
+++ b/spec/fixtures/contacts/other_existing_contact.json
@@ -1,0 +1,20 @@
+{
+  "id": 888000000,
+  "email": "test@example.com",
+  "phone": "4444444444",
+  "ama_rewards": "0",
+  "ama_membership": "0",
+  "ama_insurance": "0",
+  "ama_travel": "0",
+  "ama_new_member_series": "0",
+  "ama_fleet_safety": "0",
+  "ovrr_personal": "Johnson",
+  "ovrr_associate": "James",
+  "ovrr_business": "Jimmy",
+  "ama_vr_reminder": "1",
+  "ama_vr_reminder_email": "1",
+  "ama_vr_reminder_sms": "1",
+  "ama_vr_reminder_autocall": "1",
+  "cell_phone_number": "8998889999",
+  "phone_number": "4444444444"
+}


### PR DESCRIPTION
Case: If an ama member changes their email to an email that already exists in maropost.

- We merge the list params
- Set the phone and mobile phone to that of the old email
- Place the old email contact on the do not mail list.
