### PR TITLE
VSTS 12814 - Non Member info

### DIFF
--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -31,7 +31,7 @@ module Maropost
         service = Service.new(
           method: :post,
           path: 'contacts.json',
-          payload: create_or_update_payload(contact)
+          payload: create_payload(contact)
         )
         response = JSON.parse(service.execute!.body)
         Maropost::Contact.new(response)
@@ -44,7 +44,7 @@ module Maropost
         service = Service.new(
           method: :put,
           path: "contacts/#{contact.id}.json",
-          payload: create_or_update_payload(contact)
+          payload: update_payload(contact)
         )
         response = JSON.parse(service.execute!.body)
         Maropost::Contact.new(response)
@@ -83,7 +83,7 @@ module Maropost
         contact
       end
 
-      def create_or_update_payload(contact)
+      def update_payload(contact)
         {
           contact: {
             email: contact.email,
@@ -91,6 +91,10 @@ module Maropost
             custom_field: contact.list_parameters
           }
         }
+      end
+
+      def create_payload(contact)
+        update_payload(contact).merge(first_name: contact&.first_name, last_name: contact&.last_name)
       end
 
       def to_maropost(existing, contact)

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -94,7 +94,7 @@ module Maropost
       end
 
       def create_payload(contact)
-        update_payload(contact).merge(first_name: contact&.first_name, last_name: contact&.last_name)
+        update_payload(contact).merge(first_name: contact.try(:first_name), last_name: contact.try(:last_name))
       end
 
       def to_maropost(existing, contact)

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -85,8 +85,8 @@ module Maropost
 
       def create_or_update_payload(contact)
         payload(contact).tap do |p|
-          p.merge(first_name: contact.try(:first_name)) if contact.try(:first_name)
-          p.merge(last_name: contact.try(:last_name)) if contact.try(:last_name)
+          p[:contact][:first_name] = contact.try(:first_name) if contact.try(:first_name)
+          p[:contact][:last_name] = contact.try(:last_name) if contact.try(:last_name)
         end
       end
 

--- a/lib/maropost/api.rb
+++ b/lib/maropost/api.rb
@@ -31,7 +31,7 @@ module Maropost
         service = Service.new(
           method: :post,
           path: 'contacts.json',
-          payload: create_payload(contact)
+          payload: create_or_update_payload(contact)
         )
         response = JSON.parse(service.execute!.body)
         Maropost::Contact.new(response)
@@ -44,7 +44,7 @@ module Maropost
         service = Service.new(
           method: :put,
           path: "contacts/#{contact.id}.json",
-          payload: update_payload(contact)
+          payload: create_or_update_payload(contact)
         )
         response = JSON.parse(service.execute!.body)
         Maropost::Contact.new(response)
@@ -83,7 +83,14 @@ module Maropost
         contact
       end
 
-      def update_payload(contact)
+      def create_or_update_payload(contact)
+        payload(contact).tap do |p|
+          p.merge(first_name: contact.try(:first_name)) if contact.try(:first_name)
+          p.merge(last_name: contact.try(:last_name)) if contact.try(:last_name)
+        end
+      end
+
+      def payload(contact)
         {
           contact: {
             email: contact.email,
@@ -91,10 +98,6 @@ module Maropost
             custom_field: contact.list_parameters
           }
         }
-      end
-
-      def create_payload(contact)
-        update_payload(contact).merge(first_name: contact.try(:first_name), last_name: contact.try(:last_name))
       end
 
       def to_maropost(existing, contact)

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -36,6 +36,8 @@ module Maropost
       self.id = data[:id]
       self.email = data[:email]
       self.phone_number = data[:phone]
+      self.first_name = data[:first_name]
+      self.last_name = data[:last_name]
       self.cell_phone_number = data[:cell_phone_number]
       self.allow_emails = data.fetch(:allow_emails) { !DoNotMailList.exists?(self) }
       self.errors = []

--- a/lib/maropost/contact.rb
+++ b/lib/maropost/contact.rb
@@ -7,6 +7,8 @@ module Maropost
       id
       email
       phone_number
+      first_name
+      last_name
       cell_phone_number
       lists
       errors

--- a/lib/maropost/version.rb
+++ b/lib/maropost/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Maropost
-  VERSION = '0.8.2'
+  VERSION = '0.9.0'
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -125,6 +125,17 @@ describe Maropost::Api do
     end
   end
 
+  describe 'creates with first name and last name' do
+    subject { Maropost::Api.create(Maropost::Contact.new(email: email, first_name: 'Homer', last_name: 'Simpson')) }
+
+    context 'is successful' do
+      it 'creates the contact in maropost' do
+        stub_create_maropost_contact
+        expect(subject.errors).to be_empty
+      end
+    end
+  end
+
   describe 'create' do
     subject { Maropost::Api.create(Maropost::Contact.new(email: email)) }
 


### PR DESCRIPTION
* We want to create a person in Maropost after they give us their non-member
information. However, the Maropost gem is not configured to take first
and last name so we have to add it because they are basic attributes
* Trying to minimize impact on other parts of the gem so we don't
overwrite stuff in an update that may already be there if we use the
update

https://amaabca.visualstudio.com/online_account_single_sign_on/_workitems/edit/12814